### PR TITLE
add: pre-order ray casting

### DIFF
--- a/del-msh-core/src/bvh3.rs
+++ b/del-msh-core/src/bvh3.rs
@@ -219,7 +219,7 @@ where
     let intersect_fun = |node: Index, max_dis: f32| {
         pre_order_first_intersection_ray(ray_org, ray_dir, trimesh3, node.as_(), max_dis)
     };
-    
+
     match compare_aabb_ray(trimesh3, l_bvh_i, r_bvh_i, ray_dir) {
         AABBStatus::Seperated(near, far) => {
             // no need to check far node if hit in near


### PR DESCRIPTION
Dear prof,
Thank you for your implementation of bvh intersecton. 

I noticed your implementation is using post-order branch selecting. 
Out of curiosity, I implement pre-order branch selecting(check AABB before go into deeper branch) and observered that pre-order method is slower than post-order(about 20%). 

 I haven't figure out why but I think it is interesting, So I made this pr.