### PR TITLE
Fix perspective rasterized edge gradients

### DIFF
--- a/del-msh-cpu/src/rasterized_edge_gradient.rs
+++ b/del-msh-cpu/src/rasterized_edge_gradient.rs
@@ -47,6 +47,32 @@ fn fn_inside(b: Option<[f32; 3]>) -> bool {
     }
 }
 
+/// Gradient of one perspective-divided pixel coordinate with respect to a
+/// world-space vertex. `axis` is 0 for pixel x and 1 for pixel y.
+fn fn_projection_gradient(
+    transform_world2pix: &[f32; 16],
+    xyz: &[f32; 3],
+    axis: usize,
+) -> Option<[f32; 3]> {
+    let q = transform_world2pix[axis] * xyz[0]
+        + transform_world2pix[axis + 4] * xyz[1]
+        + transform_world2pix[axis + 8] * xyz[2]
+        + transform_world2pix[axis + 12];
+    let w = transform_world2pix[3] * xyz[0]
+        + transform_world2pix[7] * xyz[1]
+        + transform_world2pix[11] * xyz[2]
+        + transform_world2pix[15];
+    if w.abs() <= f32::EPSILON {
+        return None;
+    }
+    let inv_w2 = 1.0 / (w * w);
+    Some([
+        (transform_world2pix[axis] * w - q * transform_world2pix[3]) * inv_w2,
+        (transform_world2pix[axis + 4] * w - q * transform_world2pix[7]) * inv_w2,
+        (transform_world2pix[axis + 8] * w - q * transform_world2pix[11]) * inv_w2,
+    ])
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn edge_gradient_and_type(
     tri2vtx: &[u32],
@@ -419,8 +445,6 @@ pub fn bwd(
     assert_eq!(pix2val.len(), img_h * img_w * num_vdim);
     assert_eq!(dldw_pix2val.len(), img_h * img_w * num_vdim);
     assert_eq!(vtx2xyz.len(), dldw_vtx2xyz.len());
-    use del_geo_core::mat4_col_major::Mat4ColMajor;
-    let transform_pix2world = transform_world2pix.transpose();
     // vertical edge
     for iw in 0..img_w {
         for ih0 in 0..img_h - 1 {
@@ -470,10 +494,12 @@ pub fn bwd(
                 let b = fn_barycentric(tri2vtx, vtx2xyz, &pixcntr1, itri1, transform_world2pix)
                     .unwrap();
                 let itri1 = itri1 as usize;
-                use del_geo_core::mat4_col_major::Mat4ColMajor;
-                let dxyz = transform_pix2world.transform_direction(&[0., 1., 0.]);
                 for inode in 0..3 {
                     let ivtx = tri2vtx[itri1 * 3 + inode] as usize;
+                    let xyz = arrayref::array_ref![vtx2xyz, ivtx * 3, 3];
+                    let Some(dxyz) = fn_projection_gradient(transform_world2pix, xyz, 1) else {
+                        continue;
+                    };
                     dldw_vtx2xyz[ivtx * 3] += b[inode] * dxyz[0] * dldpa;
                     dldw_vtx2xyz[ivtx * 3 + 1] += b[inode] * dxyz[1] * dldpa;
                     dldw_vtx2xyz[ivtx * 3 + 2] += b[inode] * dxyz[2] * dldpa;
@@ -483,10 +509,12 @@ pub fn bwd(
                 let b = fn_barycentric(tri2vtx, vtx2xyz, &pixcntr0, itri0, transform_world2pix)
                     .unwrap();
                 let itri0 = itri0 as usize;
-                use del_geo_core::mat4_col_major::Mat4ColMajor;
-                let dxyz = transform_pix2world.transform_direction(&[0., 1., 0.]);
                 for inode in 0..3 {
                     let ivtx = tri2vtx[itri0 * 3 + inode] as usize;
+                    let xyz = arrayref::array_ref![vtx2xyz, ivtx * 3, 3];
+                    let Some(dxyz) = fn_projection_gradient(transform_world2pix, xyz, 1) else {
+                        continue;
+                    };
                     dldw_vtx2xyz[ivtx * 3] += b[inode] * dxyz[0] * dldpa;
                     dldw_vtx2xyz[ivtx * 3 + 1] += b[inode] * dxyz[1] * dldpa;
                     dldw_vtx2xyz[ivtx * 3 + 2] += b[inode] * dxyz[2] * dldpa;
@@ -544,10 +572,12 @@ pub fn bwd(
                 let b = fn_barycentric(tri2vtx, vtx2xyz, &pixcntr1, itri1, transform_world2pix)
                     .unwrap();
                 let itri1 = itri1 as usize;
-                use del_geo_core::mat4_col_major::Mat4ColMajor;
-                let dxyz = transform_pix2world.transform_direction(&[1., 0., 0.]);
                 for inode in 0..3 {
                     let ivtx = tri2vtx[itri1 * 3 + inode] as usize;
+                    let xyz = arrayref::array_ref![vtx2xyz, ivtx * 3, 3];
+                    let Some(dxyz) = fn_projection_gradient(transform_world2pix, xyz, 0) else {
+                        continue;
+                    };
                     dldw_vtx2xyz[ivtx * 3] += b[inode] * dxyz[0] * dldpa;
                     dldw_vtx2xyz[ivtx * 3 + 1] += b[inode] * dxyz[1] * dldpa;
                     dldw_vtx2xyz[ivtx * 3 + 2] += b[inode] * dxyz[2] * dldpa;
@@ -557,10 +587,12 @@ pub fn bwd(
                 let b = fn_barycentric(tri2vtx, vtx2xyz, &pixcntr0, itri0, transform_world2pix)
                     .unwrap();
                 let itri0 = itri0 as usize;
-                use del_geo_core::mat4_col_major::Mat4ColMajor;
-                let dxyz = transform_pix2world.transform_direction(&[1., 0., 0.]);
                 for inode in 0..3 {
                     let ivtx = tri2vtx[itri0 * 3 + inode] as usize;
+                    let xyz = arrayref::array_ref![vtx2xyz, ivtx * 3, 3];
+                    let Some(dxyz) = fn_projection_gradient(transform_world2pix, xyz, 0) else {
+                        continue;
+                    };
                     dldw_vtx2xyz[ivtx * 3] += b[inode] * dxyz[0] * dldpa;
                     dldw_vtx2xyz[ivtx * 3 + 1] += b[inode] * dxyz[1] * dldpa;
                     dldw_vtx2xyz[ivtx * 3 + 2] += b[inode] * dxyz[2] * dldpa;

--- a/del-msh-cuda-kernels/cuda/rasterized_edge_gradient.cu
+++ b/del-msh-cuda-kernels/cuda/rasterized_edge_gradient.cu
@@ -1,4 +1,5 @@
 #include <cuda_runtime.h>
+#include <cfloat>
 #include "del_geo/mat4_col_major.h"
 #include "del_geo/tri2.h"
 
@@ -356,8 +357,32 @@ __device__ bool barycentric_of_pixel_in_tri(
     return true;
 }
 
+// Jacobian row of one perspective-divided pixel coordinate with respect to a
+// world-space vertex. axis=0 selects pixel x and axis=1 selects pixel y.
+__device__ bool projection_gradient(
+    const float *transform_world2pix,
+    const float *xyz,
+    const int axis,
+    float *dxyz)
+{
+    const float q = transform_world2pix[axis] * xyz[0]
+        + transform_world2pix[axis + 4] * xyz[1]
+        + transform_world2pix[axis + 8] * xyz[2]
+        + transform_world2pix[axis + 12];
+    const float w = transform_world2pix[3] * xyz[0]
+        + transform_world2pix[7] * xyz[1]
+        + transform_world2pix[11] * xyz[2]
+        + transform_world2pix[15];
+    if (fabsf(w) <= FLT_EPSILON) { return false; }
+    const float inv_w2 = 1.f / (w * w);
+    dxyz[0] = (transform_world2pix[axis] * w - q * transform_world2pix[3]) * inv_w2;
+    dxyz[1] = (transform_world2pix[axis + 4] * w - q * transform_world2pix[7]) * inv_w2;
+    dxyz[2] = (transform_world2pix[axis + 8] * w - q * transform_world2pix[11]) * inv_w2;
+    return true;
+}
+
 // Backward pass for horizontal edges (each edge connects pixel (iw,ih0) and
-// (iw,ih0+1)).  Uses direction [0,1,0] through transpose(transform_world2pix).
+// (iw,ih0+1)). Uses the perspective-correct pixel-y projection Jacobian.
 // Thread (x=iw, y=ih0), grid covers img_w × (img_h-1).
 __global__
 void bwd_hedge(
@@ -399,14 +424,6 @@ void bwd_hedge(
         dldpa += (dval0 + dval1) * 0.5f * (val0 - val1);
     }
 
-    // transform_pix2world.transform_direction([0,1,0])
-    // = transpose(w2p) * [0,1,0,0] = [w2p[1], w2p[5], w2p[9]]
-    const float dxyz[3] = {
-        transform_world2pix[1],
-        transform_world2pix[5],
-        transform_world2pix[9],
-    };
-
     uint32_t target_tri;
     float pxq, pyq;
     if (in1_tri0) {
@@ -425,6 +442,8 @@ void bwd_hedge(
     }
     for (int inode = 0; inode < 3; ++inode) {
         const uint32_t ivtx = tri2vtx[target_tri * 3 + inode];
+        float dxyz[3];
+        if (!projection_gradient(transform_world2pix, vtx2xyz + ivtx * 3, 1, dxyz)) { continue; }
         atomicAdd(&dldw_vtx2xyz[ivtx * 3 + 0], bary[inode] * dxyz[0] * dldpa);
         atomicAdd(&dldw_vtx2xyz[ivtx * 3 + 1], bary[inode] * dxyz[1] * dldpa);
         atomicAdd(&dldw_vtx2xyz[ivtx * 3 + 2], bary[inode] * dxyz[2] * dldpa);
@@ -432,7 +451,7 @@ void bwd_hedge(
 }
 
 // Backward pass for vertical edges (each edge connects pixel (iw0,ih) and
-// (iw0+1,ih)).  Uses direction [1,0,0] through transpose(transform_world2pix).
+// (iw0+1,ih)). Uses the perspective-correct pixel-x projection Jacobian.
 // Thread (x=iw0, y=ih), grid covers (img_w-1) × img_h.
 __global__
 void bwd_vedge(
@@ -474,14 +493,6 @@ void bwd_vedge(
         dldpa += (dval0 + dval1) * 0.5f * (val0 - val1);
     }
 
-    // transform_pix2world.transform_direction([1,0,0])
-    // = transpose(w2p) * [1,0,0,0] = [w2p[0], w2p[4], w2p[8]]
-    const float dxyz[3] = {
-        transform_world2pix[0],
-        transform_world2pix[4],
-        transform_world2pix[8],
-    };
-
     uint32_t target_tri;
     float pxq, pyq;
     if (in1_tri0) {
@@ -500,6 +511,8 @@ void bwd_vedge(
     }
     for (int inode = 0; inode < 3; ++inode) {
         const uint32_t ivtx = tri2vtx[target_tri * 3 + inode];
+        float dxyz[3];
+        if (!projection_gradient(transform_world2pix, vtx2xyz + ivtx * 3, 0, dxyz)) { continue; }
         atomicAdd(&dldw_vtx2xyz[ivtx * 3 + 0], bary[inode] * dxyz[0] * dldpa);
         atomicAdd(&dldw_vtx2xyz[ivtx * 3 + 1], bary[inode] * dxyz[1] * dldpa);
         atomicAdd(&dldw_vtx2xyz[ivtx * 3 + 2], bary[inode] * dxyz[2] * dldpa);

--- a/del-msh-dlpack/del_msh_dlpack/RasterizedEdgeGradient/torch.py
+++ b/del-msh-dlpack/del_msh_dlpack/RasterizedEdgeGradient/torch.py
@@ -257,13 +257,18 @@ class AutogradWithSmooth(torch.autograd.Function):
         write_velocity_on_staggered_grid(path0, hedge2dldr, vedge2dldr)
         """
         #
-        from del_msh_dlpack.Vtx2Xyz.torch import transform_affine
-
-        vtx2wh = transform_affine(vtx2xyz, transform_world2pix)[:, 0:2].clone()
+        # Project vertices with homogeneous division.  ``transform_affine`` is
+        # insufficient here because world-to-pixel may be a perspective matrix.
+        ones = torch.ones_like(vtx2xyz[:, :1])
+        vtx2xyzw = torch.cat([vtx2xyz, ones], dim=1) @ transform_world2pix.T
+        vtx2wh = vtx2xyzw[:, 0:2] / vtx2xyzw[:, 3:4]
         dldw_vtx2wh = interpolate(hedge2dldr, vedge2dldr, vtx2wh)
-        zeros = torch.zeros(
-            (dldw_vtx2wh.shape[0], 1), dtype=torch.float, device=dldw_vtx2wh.device
-        )
-        dldw_vtx2whdw = torch.cat([dldw_vtx2wh, zeros, zeros], dim=1)  # (N,4)
-        dldw_vtx2xyz = (dldw_vtx2whdw @ transform_world2pix.clone())[:, 0:3].clone()
+        # Chain through q.xy / q.w, then through q = M @ [xyz, 1].
+        qx, qy, qw = vtx2xyzw[:, 0], vtx2xyzw[:, 1], vtx2xyzw[:, 3]
+        gx, gy = dldw_vtx2wh[:, 0], dldw_vtx2wh[:, 1]
+        dldw_q = torch.zeros_like(vtx2xyzw)
+        dldw_q[:, 0] = gx / qw
+        dldw_q[:, 1] = gy / qw
+        dldw_q[:, 3] = -(gx * qx + gy * qy) / (qw * qw)
+        dldw_vtx2xyz = (dldw_q @ transform_world2pix)[:, 0:3].clone()
         return None, dldw_vtx2xyz, None, None, dldw_pix2val

--- a/del-msh-dlpack/del_msh_dlpack/RasterizedEdgeGradient/torch.py
+++ b/del-msh-dlpack/del_msh_dlpack/RasterizedEdgeGradient/torch.py
@@ -223,7 +223,12 @@ class RasterizedEdgeGradientFunction(torch.autograd.Function):
     def backward(ctx, dldw_pix2vout):
         tri2vtx, vtx2xyz, transform_world2pix, pix2tri, pix2vin = ctx.saved_tensors
         dldw_vtx2xyz = bwd(
-            tri2vtx, vtx2xyz.detach(), transform_world2pix, dldw_pix2vout, pix2tri
+            tri2vtx,
+            vtx2xyz.detach(),
+            transform_world2pix,
+            pix2tri,
+            pix2vin.detach(),
+            dldw_pix2vout,
         )
         dldw_pix2vin = dldw_pix2vout.clone()
         return None, dldw_vtx2xyz, None, None, dldw_pix2vin

--- a/del-msh-dlpack/src/rasterized_edge_gradient.rs
+++ b/del-msh-dlpack/src/rasterized_edge_gradient.rs
@@ -68,8 +68,8 @@ pub fn rasterized_edge_gradient_bwd(
                 (img_w as usize, img_h as usize),
                 slice!(pix2tri, u32).unwrap(),
                 num_vdim as usize,
-                slice!(dldw_pix2val, f32).unwrap(),
                 slice!(pix2val, f32).unwrap(),
+                slice!(dldw_pix2val, f32).unwrap(),
             );
         }
         #[cfg(feature = "cuda")]
@@ -104,8 +104,8 @@ pub fn rasterized_edge_gradient_bwd(
                 builder.arg_u32(img_h as u32);
                 builder.arg_data(&pix2tri.data);
                 builder.arg_u32(num_vdim as u32);
-                builder.arg_data(&dldw_pix2val.data); // swapped: mirrors CPU call order
                 builder.arg_data(&pix2val.data);
+                builder.arg_data(&dldw_pix2val.data);
                 builder.launch_kernel(func, cfg).unwrap();
             }
             // vedge: grid covers (img_w - 1) × img_h
@@ -134,8 +134,8 @@ pub fn rasterized_edge_gradient_bwd(
                 builder.arg_u32(img_h as u32);
                 builder.arg_data(&pix2tri.data);
                 builder.arg_u32(num_vdim as u32);
-                builder.arg_data(&dldw_pix2val.data); // swapped: mirrors CPU call order
                 builder.arg_data(&pix2val.data);
+                builder.arg_data(&dldw_pix2val.data);
                 builder.launch_kernel(func, cfg).unwrap();
             }
         }


### PR DESCRIPTION

- Fix reversed `pix2val` and `dldw_pix2val` arguments.
- Fix the raw PyTorch autograd wrapper.
- Apply the perspective-division Jacobian when mapping screen-space gradients to 3D vertices.
- Apply the same correction to `AutogradWithSmooth`.